### PR TITLE
Add context-use post-doc placeholder

### DIFF
--- a/projects/context-use/index.md
+++ b/projects/context-use/index.md
@@ -22,10 +22,11 @@ Team members include Ian Bruce (McMaster), Emily Myers and Thomas Hinchey (UConn
 
 Openings:
 
-- The research assistant position is posted with [Job ID 66171](https://careers.mcmaster.ca/psp/prcsprd/EMPLOYEE/HRMS/c/HRS_HRAM.HRS_APP_SCHJOB.GBL?Page=HRS_APP_JBPST&Action=U&FOCUS=Applicant&SiteId=1001&JobOpeningId=66171&PostingSeq=1);
+- Full-time Research Assistant ([Job ID 66171](https://careers.mcmaster.ca/psp/prcsprd/EMPLOYEE/HRMS/c/HRS_HRAM.HRS_APP_SCHJOB.GBL?Page=HRS_APP_JBPST&Action=U&FOCUS=Applicant&SiteId=1001&JobOpeningId=66171&PostingSeq=1)):
   this position could be ideal for a recent graduate with a Bachelor's degree who would like to gain more experience before applying for graduate school;
   the initial offer is for a year but with potential for renewal;
   please feel free to reach out with questions
+- Post-Doctoral Fellow: will be posted soon
 - Candidates for the PhD program can reach out to me to discuss suitability (we have rolling admissions and do not get notified automatically of [formal applications](https://applygrad.mcmaster.ca/portal/start_your_app))
 
 This project is funded by [NIH](https://reporter.nih.gov/search/S0ABSkf4iE2GqIQnNxTKsg/project-details/10804052).

--- a/projects/ncrf/index.md
+++ b/projects/ncrf/index.md
@@ -18,7 +18,7 @@ Ideal candidates should have experience and interests in the following areas: si
 
 Openings:
 
- - The post-doctoral positions at McMaster are posted with [Job ID 66108](https://careers.mcmaster.ca/psp/prcsprd/EMPLOYEE/HRMS/c/HRS_HRAM.HRS_APP_SCHJOB.GBL?Page=HRS_APP_JBPST&Action=U&FOCUS=Applicant&SiteId=1001&JobOpeningId=66108&PostingSeq=1)
+ - The Post-Doctoral Fellow positions at McMaster are posted with [Job ID 66108](https://careers.mcmaster.ca/psp/prcsprd/EMPLOYEE/HRMS/c/HRS_HRAM.HRS_APP_SCHJOB.GBL?Page=HRS_APP_JBPST&Action=U&FOCUS=Applicant&SiteId=1001&JobOpeningId=66108&PostingSeq=1)
  - Candidates for the PhD program can reach out to me to discuss suitability (we have rolling admissions and do not get notified automatically of [formal applications](https://applygrad.mcmaster.ca/portal/start_your_app))
 
 


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
