### PR TITLE
UPDATE: remove 'Context Use' job listings

### DIFF
--- a/projects/context-use/index.md
+++ b/projects/context-use/index.md
@@ -10,24 +10,18 @@ A common strategy that listeners use in such situations is to use the linguistic
 The goal of this project is developing and testing explicit models of context use in continuous speech, how context use changes with age, and how it interacts with hearing loss.
 To test these models we will collect EEG and fMRI data, together with a range of cognitive and hearing related measures.
 
-We are looking for a **full-time research assistant** to 
-lead the implementation of the experiments and data collection. We are also looking for a **post-doc** and **graduate students** interested in all aspects of this research, including:
-implementation of computational models for context use, 
-language models and their relationship to human speech processing, 
+We have an opening for
+a **graduate student** interested in 
+computational models of human speech and language perception 
+and their relationship to human speech processing, 
 cognitive aging,
-auditory neuroscience,
-and neuroimaging (EEG, functional and structural MRI).
+and neural data (EEG, functional and structural MRI).
 
 The researchers will be part of multidisciplinary team including experts in Neuroscience, Hearing and Speech, Hearing Technology, and Aging. 
 Team members include Ian Bruce (McMaster), Emily Myers and Thomas Hinchey (UConn) and Samira Anderson (U Maryland).
 
 Openings:
 
- - Full-time Research Assistant:
-   This position could be ideal for a recent graduate, with a Bachelor's degree related to neuroscience or audiology, who would like to gain more experience before applying for graduate school.
-   You will gain hands-on experience implementing and conducting hearing tests and cognitive neuroscience experiments.
-   The initial offer is for a year but with high potential for renewal.
-   Please feel free to reach out with questions
  - Candidates interested in graduate programs can reach out to me to discuss suitability (we have rolling admissions and do not get notified automatically of [formal applications](https://applygrad.mcmaster.ca/portal/start_your_app))
 
 This project is funded by [NIH](https://reporter.nih.gov/search/S0ABSkf4iE2GqIQnNxTKsg/project-details/10804052).

--- a/projects/context-use/index.md
+++ b/projects/context-use/index.md
@@ -17,7 +17,7 @@ and their relationship to human speech processing,
 cognitive aging,
 and neural data (EEG, functional and structural MRI).
 
-The researchers will be part of multidisciplinary team including experts in Neuroscience, Hearing and Speech, Hearing Technology, and Aging. 
+The researcher will be part of multidisciplinary team including experts in Neuroscience, Hearing and Speech, Hearing Technology, and Aging. 
 Team members include Ian Bruce (McMaster), Emily Myers and Thomas Hinchey (UConn) and Samira Anderson (U Maryland).
 
 Openings:


### PR DESCRIPTION
This website is based on the Lab Website Template.
See its documentation for working with this site:

https://greene-lab.gitbook.io/lab-website-template-docs
